### PR TITLE
make jshint ignore the generated scenario data

### DIFF
--- a/tasks/scenarioData.tpl
+++ b/tasks/scenarioData.tpl
@@ -1,4 +1,5 @@
 /* global angular */
+/* jshint ignore:start */
 
 angular
   .module('scenario')
@@ -7,3 +8,4 @@ angular
     scenarioMockDataProvider.setDefaultScenario('_default');
     scenarioMockDataProvider.setMockData(<%= scenarioData %>);
   }]);
+/* jshint ignore:end */

--- a/tasks/scenarioData.tpl
+++ b/tasks/scenarioData.tpl
@@ -1,11 +1,11 @@
 /* global angular */
-/* jshint ignore:start */
 
 angular
   .module('scenario')
 
   .config(['scenarioMockDataProvider', function (scenarioMockDataProvider) {
     scenarioMockDataProvider.setDefaultScenario('_default');
+    /* jshint ignore:start */
     scenarioMockDataProvider.setMockData(<%= scenarioData %>);
+    /* jshint ignore:end */
   }]);
-/* jshint ignore:end */


### PR DESCRIPTION
because the lines are too long, or any other jshint errors that might
get thrown
